### PR TITLE
chore: improve naming and provide intro docs

### DIFF
--- a/.github/workflows/dummy.yml
+++ b/.github/workflows/dummy.yml
@@ -22,6 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run Molecule scenario "defaults"
+        run: make test
         env:
           ANSIBLE_MOLECULE_ROLE: dummy
           ANSIBLE_MOLECULE_SCENARIO: defaults
@@ -29,4 +30,3 @@ jobs:
           ANSIBLE_MOLECULE_GROUP: dummy_group
           # TODO: consider removing this vault password if not needed
           ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
-        run: make test

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,6 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   lint:
-    name: Lint repository
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,7 +7,6 @@ on:  # yamllint disable-line rule:truthy
 
 jobs:
   version:
-    name: Generate version and create tag
     runs-on: ubuntu-22.04
 
     steps:
@@ -32,7 +31,6 @@ jobs:
           body: ${{ steps.tag_version.outputs.changelog }}
 
   build:
-    name: Build and publish
     needs: version
     runs-on: ubuntu-22.04
 
@@ -43,9 +41,9 @@ jobs:
           fetch-depth: 0
 
       - name: Build collection package
-        run: make collection-build
+        run: make build-collection
 
       - name: Publish collection package
+        run: make build-collection
         env:
           ANSIBLE_GALAXY_TOKEN: ${{ secrets.ANSIBLE_GALAXY_TOKEN }}
-        run: make collection-publish

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
-.docker.conf
+.docker
 dist
 environment/context
 pb_*.y*ml
-# not sure needed
-__pycache__

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,11 @@ push-docker-ansible-ee:
 	$(DOCKER) --config $(DOCKER_CONFIG) push $(DOCKER_IMAGE_EE):$(DOCKER_IMAGE_EE_VERSION)
 	$(DOCKER) --config $(DOCKER_CONFIG) push $(DOCKER_IMAGE_EE):$(DOCKER_IMAGE_EE_TAG_LATEST)
 
+.PHONY: logout-docker
+	$(DOCKER) --config $(DOCKER_CONFIG) logout $(DOCKER_REGISTRY)
+
 .PHONY: docker-ansible-ee
-docker-ansible-ee: login-docker build-docker-ansible-ee push-docker-ansible-ee
+docker-ansible-ee: login-docker build-docker-ansible-ee push-docker-ansible-ee logout-docker
 
 
 # LINT
@@ -91,15 +94,15 @@ test:
 
 # RELEASE
 
-.PHONY: collection-build
-collection-build:
+.PHONY: build-collection
+build-collection:
 	$(DOCKER_RUN) rm -rf dist && mkdir -p dist
 	$(DOCKER_RUN) sed -i 's/version: 0.0.0/version: $(ANSIBLE_COLLECTION_VERSION)/' galaxy.yml
 	$(DOCKER_RUN) ansible-galaxy collection build . --output-path dist
 	$(DOCKER_RUN) sed -i 's/version: $(ANSIBLE_COLLECTION_VERSION)/version: 0.0.0/' galaxy.yml
 
-.PHONY: collection-publish
-collection-publish: collection-build
+.PHONY: publish-collection
+publish-collection: build-collection
 	$(DOCKER_RUN) ansible-galaxy collection publish dist/$(ANSIBLE_COLLECTION_ARCHIVE_FILENAME) --token $(ANSIBLE_GALAXY_TOKEN)
 	rm -rf dist
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-Ansible collection: jrgoldfinemiddleton.digitalocean
+# Ansible collection: jrgoldfinemiddleton.digitalocean
+
+## Testing locally
+
+You will likely want to set some of the following environment variables, as needed, depending on which `make` targets you will be running.
+
+* `ANSIBLE_COLLECTION_VERSION`
+* `ANSIBLE_GALAXY_TOKEN`
+* `ANSIBLE_MOLECULE_GROUP`
+* `ANSIBLE_MOLECULE_ROLE`
+* `ANSIBLE_MOLECULE_SCENARIO`
+* `ANSIBLE_VAULT_PASSWORD`
+* `DO_API_TOKEN`
+* `DOCKER_CONFIG`
+* `DOCKER_IMAGE_EE`
+* `DOCKER_PASSWORD`
+* `DOCKER_REGISTRY`
+* `DOCKER_USERNAME`
+
+Review the [Makefile](https://github.com/jrgoldfinemiddleton/ansible-collection-digitalocean/blob/main/Makefile) to learn what each environment variable is used for.


### PR DESCRIPTION
* Rename make targets with verb-noun convention
* Remove names for GitHub Actions jobs
* Supply preliminary hints regarding manual usage of make targets